### PR TITLE
Update exif.js

### DIFF
--- a/exif.js
+++ b/exif.js
@@ -704,7 +704,9 @@
                     case "FileSource" :
                         exifData[tag] = StringValues[tag][exifData[tag]];
                         break;
-
+                    case "ExposureTime" :
+						exifData[tag] = exifData[tag].numerator + "/" + exifData[tag].denominator +"s";
+						break;
                     case "ExifVersion" :
                     case "FlashpixVersion" :
                         exifData[tag] = String.fromCharCode(exifData[tag][0], exifData[tag][1], exifData[tag][2], exifData[tag][3]);


### PR DESCRIPTION
changed the output of 'exposure time' from decimal to fraction which is the standard way to express shutter speed.
(0.001 becomes 1/1000s)